### PR TITLE
Fix ArgumentOutOfRangeException when calling CheckMonthAsync

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -8,7 +8,7 @@ on:
 env:
   APP_NAME: isdayoff                                        # set this to your application's name
   APP_PACKAGE_PATH: './published'                           # set this to the path to your app project, defaults to the repository root
-  NETCORE_VERSION: '3.1.200'                                # set this to the .NET Core version to use
+  NETCORE_VERSION: '5.0.103'                                # set this to the .NET Core version to use
   GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}   # set this to access token to github.com
   GITHUB_API_KEY: ${{ github.token }}                         # set this to access token to github.com
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}               # set this to access token to nuget.org

--- a/.github/workflows/check-in.yml
+++ b/.github/workflows/check-in.yml
@@ -1,7 +1,8 @@
 name: Check-in
 
 env:
-  GITHUB_TOKEN: ${{ github.token }}                         # set this to access token to github.com
+  NETCORE_VERSION: '5.0.103'                                # set this to the .NET Core version to use
+  GITHUB_API_KEY: ${{ github.token }}                       # set this to access token to github.com
 
 on:
   push:
@@ -19,7 +20,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: ${{ env.NETCORE_VERSION }}
 
       - name: Restore
         run: dotnet restore
@@ -33,5 +34,5 @@ jobs:
       - name: Publish test coverage report to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:
-          github-token: ${{ env.GITHUB_TOKEN }}
+          github-token: ${{ env.GITHUB_API_KEY }}
           path-to-lcov: ./isdayoff.Tests/coverage/lcov.info

--- a/isdayoff.Tests/IsDayOffTests/IsDayOffTestBase.cs
+++ b/isdayoff.Tests/IsDayOffTests/IsDayOffTestBase.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+using isdayoff.Contract;
+
+namespace isdayoff.Tests.IsDayOffTests
+{
+    internal class IsDayOffTestBase : TestBase
+    {
+        protected IsDayOff IsDayOff { get; private set; }
+
+        public override void Setup()
+        {
+            base.Setup();
+
+            var settings = new IsDayOffSettings(ApiBaseUrlStub, UserAgentStub, CacheStub, Country.Russia, SourceLevels.Off);
+            IsDayOff = new IsDayOff(settings, ApiClientStub);
+        }
+    }
+}

--- a/isdayoff.Tests/IsDayOffTests/WhenCheckMonth.cs
+++ b/isdayoff.Tests/IsDayOffTests/WhenCheckMonth.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace isdayoff.Tests.IsDayOffTests
+{
+    internal class WhenCheckMonth : IsDayOffTestBase
+    {
+        [Test]
+        public void NoExceptionShouldBeThrown()
+        {
+            var response = new string(Enumerable.Range(0, 31).Select(o => '0').ToArray());
+            ApiClientStub.Response = response;
+            
+            async Task Act()
+            {
+                await IsDayOff.CheckMonthAsync(2020, 01);
+            }
+
+            Assert.DoesNotThrowAsync(Act);
+        }
+    }
+}

--- a/isdayoff.Tests/isdayoff.Tests.csproj
+++ b/isdayoff.Tests/isdayoff.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/isdayoff/IsDayOff.cs
+++ b/isdayoff/IsDayOff.cs
@@ -40,7 +40,19 @@ namespace isdayoff
         /// </summary>
         /// <param name="settings">Settings</param>
         /// <exception cref="ArgumentNullException">Thrown when some not null property is set to null</exception>
-        public IsDayOff([NotNull] IsDayOffSettings settings)
+        public IsDayOff([NotNull] IsDayOffSettings settings) : this(settings, 
+                                                                    new IsDayOffApiClient(settings.ApiBaseUrl, 
+                                                                                          settings.UserAgent, 
+                                                                                          new HttpClientFactory(new HttpClientHandler())))
+        {
+        }
+
+        /// <summary>
+        /// Constructor for testing purposes. Should not be used by regular users
+        /// </summary>
+        /// <param name="settings">Settings</param>
+        /// <param name="apiClient">Api client</param>
+        internal IsDayOff([NotNull] IsDayOffSettings settings, IIsDayOffApiClient apiClient)
         {
             if (settings.TraceLevel.HasValue)
             {
@@ -48,7 +60,7 @@ namespace isdayoff
             }
             
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings), ErrorsMessages.SettingCanNotBeNull());
-            service = new IsDayOffService(new IsDayOffApiClient(settings.ApiBaseUrl, settings.UserAgent, new HttpClientFactory(new HttpClientHandler())), settings.Cache);
+            service = new IsDayOffService(apiClient, settings.Cache);
         }
         
         /// <summary>

--- a/isdayoff/IsDayOff.cs
+++ b/isdayoff/IsDayOff.cs
@@ -162,7 +162,7 @@ namespace isdayoff
         /// <exception cref="IsDayOffExternalServiceException">Throws if error occured while processing request to isdayoff external service</exception>
         public async Task<List<DayOffDateTime>> CheckMonthAsync(int year, int month, Country country, CancellationToken cancellationToken)
         {
-            var monthDateTime = new DateTime(year, month, 0);
+            var monthDateTime = new DateTime(year, month, 1);
             
             return await CheckDatesRangeAsync(monthDateTime, monthDateTime.EndOfMonth(), country, cancellationToken);
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bugfix


### :arrow_heading_down: What is the current behavior?

When the `CheckMonthAsync()` method calls - an exception is thrown:
```
System.ArgumentOutOfRangeException: Year, Month, and Day parameters describe an un-representable DateTime.
at System.DateTime.DateToTicks(Int32 year, Int32 month, Int32 day)
at System.DateTime..ctor(Int32 year, Int32 month, Int32 day)
at isdayoff.IsDayOff.CheckMonthAsync(Int32 year, Int32 month, Country country, CancellationToken cancellationToken)
at isdayoff.IsDayOff.CheckMonthAsync(Int32 year, Int32 month, CancellationToken cancellationToken)
at isdayoff.IsDayOff.CheckMonthAsync(Int32 year, Int32 month)
```

### :new: What is the new behavior (if this is a feature change)?
No exception occurs when calling `CheckMonthAsync`.

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Check month receiving.
Unit tests are written.

### :memo: Links to relevant issues/docs
fixes #1 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] All tests pass
