### PR TITLE
Add Uzbekistan and Turkey support

### DIFF
--- a/isdayoff.Tests/IsDayOffApiClientTests/WhenGetData.cs
+++ b/isdayoff.Tests/IsDayOffApiClientTests/WhenGetData.cs
@@ -67,6 +67,10 @@ namespace isdayoff.Tests.IsDayOffApiClientTests
                          {TestName = "Ukraine passes correctly", ExpectedResult = $"{ApiBaseUrlStub}getdata?date1=20200804&date2=20200804&cc=ua"};
             yield return new TestCaseData(04.08.Of(2020), 04.08.Of(2020), Country.USA, "0")
                          {TestName = "USA passes correctly", ExpectedResult = $"{ApiBaseUrlStub}getdata?date1=20200804&date2=20200804&cc=us"};
+            yield return new TestCaseData(04.08.Of(2020), 04.08.Of(2020), Country.Uzbekistan, "0")
+                         {TestName = "Uzbekistan passes correctly", ExpectedResult = $"{ApiBaseUrlStub}getdata?date1=20200804&date2=20200804&cc=uz"};
+            yield return new TestCaseData(04.08.Of(2020), 04.08.Of(2020), Country.Turkey, "0")
+                         {TestName = "Turkey passes correctly", ExpectedResult = $"{ApiBaseUrlStub}getdata?date1=20200804&date2=20200804&cc=tr"};
         }
 
         [Test]

--- a/isdayoff/Contract/Country.cs
+++ b/isdayoff/Contract/Country.cs
@@ -1,5 +1,4 @@
-﻿
-namespace isdayoff.Contract
+﻿namespace isdayoff.Contract
 {
     public enum Country
     {
@@ -7,6 +6,8 @@ namespace isdayoff.Contract
         Belarus,
         Ukraine,
         Kazakhstan,
-        USA
+        USA,
+        Uzbekistan,
+        Turkey
     }
 }

--- a/isdayoff/Core/IsDayOffApiClient.cs
+++ b/isdayoff/Core/IsDayOffApiClient.cs
@@ -120,6 +120,10 @@ namespace isdayoff.Core
                     return "kz";
                 case Country.USA:
                     return "us";
+                case Country.Uzbekistan:
+                    return "uz";
+                case Country.Turkey:
+                    return "tr";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(country), country, ErrorsMessages.UnknownCountry());
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
No support for Uzbekistan and Turkey countries, however they are supported by isdayoff api service

### :new: What is the new behavior (if this is a feature change)?
Uzbekistan and Turkey support added

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Check availability of Uzbekistan and Turkey day off information through library

### :memo: Links to relevant issues/docs
closes #3

### :thinking: Checklist before submitting

- [x] All projects build
- [x] All tests pass
